### PR TITLE
Ensure kubeclient >= 4.9.3 to avoid CVE-2022-0759

### DIFF
--- a/beaker-gke.gemspec
+++ b/beaker-gke.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'googleauth', '~> 0.9'
-  s.add_runtime_dependency 'kubeclient', '>= 4.4', '< 4.10'
+  s.add_runtime_dependency 'kubeclient', '>= 4.9.3', '< 5.0'
 end


### PR DESCRIPTION
Hi, I see your code uses `Kubeclient::Config.read(ENV['KUBECONFIG'])`.
4.9.3 fixed a severe issue in Config, in some scenarios causing insecure VERIFY_NONE connections that may leak cluster credentials — https://github.com/ManageIQ/kubeclient/issues/554

Your dependency range already allowed 4.9.3 but it's safer to disallow the older versions.